### PR TITLE
Annotation to prevent Flutter 3.x from stripping out static callback functions in release builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,14 @@ And don't forget to add the permissions to the manifest,
 
 That means the `callbackHandle` static function is guaranteed, while the channel handle function is not. This is every useful when you should persist the events to the database.
 
+> For Flutter 3.x: 
+Annotate the _callback function with `@pragma('vm:entry-point')` to prevent Flutter from stripping out this function on services.
+
 We want to run some code in background without UI thread, like persist the notifications to database or storage.
 
 1. Define your own callback to handle the incoming notifications.
     ```dart
+    @pragma('vm:entry-point')
     static void _callback(NotificationEvent evt) {
         // persist data immediately
         db.save(evt)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,6 +48,7 @@ class _NotificationsLogState extends State<NotificationsLog> {
   }
 
   // we must use static method, to handle in background
+  @pragma('vm:entry-point') // prevent dart from stripping out this function on release build in Flutter 3.x
   static void _callback(NotificationEvent evt) {
     print("send evt to ui: $evt");
     final SendPort? send = IsolateNameServer.lookupPortByName("_listener_");


### PR DESCRIPTION
This PR is in reference to this issue #24 .
Changes only needed to the readme and example project to guide users in adding the annotation.

Thanks!