### PR TITLE
Forward flags and isGroup to Dart so that group notifications can be ignored

### DIFF
--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
@@ -30,6 +30,8 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
         private const val NOTIFICATION_CAN_TAP = "canTap"
         private const val NOTIFICATION_KEY = "key"
         private const val NOTIFICATION_UNIQUE_ID = "_id"
+        private const val NOTIFICATION_FLAGS = "flags"
+        private const val NOTIFICATION_IS_GROUP = "isGroup"
 
         fun genKey(vararg items: Any?): String {
             return Utils.md5(items.joinToString(separator="-"){ "$it" }).slice(IntRange(0, 12))
@@ -49,6 +51,10 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
             map[NOTIFICATION_TIMESTAMP] = sbn.postTime
             map[NOTIFICATION_PACKAGE_NAME] =  sbn.packageName
             map[NOTIFICATION_ID] = sbn.id
+
+
+            map[NOTIFICATION_FLAGS] = notify.flags
+            map[NOTIFICATION_IS_GROUP] = (notify.flags and Notification.FLAG_GROUP_SUMMARY) != 0
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 map[NOTIFICATION_UID] = sbn.uid

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -152,6 +152,10 @@ class NotificationEvent {
   /// actions of notification
   List<Action>? actions;
 
+  int? flags;
+
+  bool? isGroup;
+
   /// the raw notifaction data from android
   dynamic _data;
 
@@ -171,6 +175,8 @@ class NotificationEvent {
     this.hasLargeIcon,
     this.largeIcon,
     this.canTap,
+    this.flags,
+    this.isGroup,
   });
 
   Map<dynamic, dynamic>? get raw => _data;
@@ -195,6 +201,8 @@ class NotificationEvent {
       hasLargeIcon: map['hasLargeIcon'],
       largeIcon: map['largeIcon'],
       canTap: map["canTap"],
+      flags: map["flags"],
+      isGroup: map["isGroup"],
     );
 
     // set the raw data


### PR DESCRIPTION
In Dart, simply check isGroup and if it is true, do not use the notification. That will get rid of the duplicate notification issue. 