### PR TITLE
Fix android high version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'im.zoe.labs.flutter_notification_listener'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,13 +25,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 23
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 05 09:48:27 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
@@ -2,7 +2,7 @@ package im.zoe.labs.flutter_notification_listener
 
 import android.app.ActivityManager
 import android.content.*
-import android.content.Context.RECEIVER_NOT_EXPORTED
+import android.content.Context.RECEIVER_EXPORTED
 import android.os.Build
 import android.util.Log
 import androidx.annotation.NonNull

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
@@ -47,7 +47,7 @@ class FlutterNotificationListenerPlugin : FlutterPlugin, MethodChannel.MethodCal
       eventChannel = event
       event.setStreamHandler(this)
     }
-
+    Log.i(TAG, "Attaching FlutterJNI to native")
     flutterJNI.attachToNative() 
 
     // store the flutter engine
@@ -78,7 +78,9 @@ class FlutterNotificationListenerPlugin : FlutterPlugin, MethodChannel.MethodCal
       event.setStreamHandler(null) 
       eventChannel = null 
     }
-    flutterJNI.attachToNative() 
+
+    Log.i(TAG, "Detaching FlutterJNI from native")
+    flutterJNI.detachFromNativeAndReleaseResources()
   }
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
@@ -57,8 +57,11 @@ class FlutterNotificationListenerPlugin : FlutterPlugin, MethodChannel.MethodCal
     val receiver = NotificationReceiver()
     val intentFilter = IntentFilter()
     intentFilter.addAction(NotificationsHandlerService.NOTIFICATION_INTENT)
-    mContext.registerReceiver(receiver, intentFilter)
-
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+         mContext.registerReceiver(broadcastReceiver, intentFilter, RECEIVER_EXPORTED)
+    }else {
+         mContext. registerReceiver(broadcastReceiver, intentFilter)
+    }
     Log.i(TAG, "attached engine finished")
   }
 

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
@@ -58,9 +58,9 @@ class FlutterNotificationListenerPlugin : FlutterPlugin, MethodChannel.MethodCal
     val intentFilter = IntentFilter()
     intentFilter.addAction(NotificationsHandlerService.NOTIFICATION_INTENT)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-         mContext.registerReceiver(broadcastReceiver, intentFilter, RECEIVER_EXPORTED)
+      mContext.registerReceiver(receiver, intentFilter, RECEIVER_EXPORTED)
     }else {
-         mContext. registerReceiver(broadcastReceiver, intentFilter)
+      mContext.registerReceiver(receiver, intentFilter)
     }
     Log.i(TAG, "attached engine finished")
   }

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/FlutterNotificationListenerPlugin.kt
@@ -2,6 +2,7 @@ package im.zoe.labs.flutter_notification_listener
 
 import android.app.ActivityManager
 import android.content.*
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.os.Build
 import android.util.Log
 import androidx.annotation.NonNull

--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
@@ -138,7 +138,7 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
 
         @RequiresApi(Build.VERSION_CODES.M)
         private fun convertIconToByteArray(context: Context, icon: Icon): ByteArray {
-            return convertBitmapToByteArray(icon.loadDrawable(context).toBitmap())
+            return convertBitmapToByteArray(icon.loadDrawable(context)!!.toBitmap())
         }
 
         private fun convertBitmapToByteArray(bitmap: Bitmap): ByteArray {


### PR DESCRIPTION
Since Android 14 there is a requirement to specify the export flag when registering context-registered receivers - https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported